### PR TITLE
Give the vents table context of a user via a userId column

### DIFF
--- a/app/controllers/JobController.ts
+++ b/app/controllers/JobController.ts
@@ -1,23 +1,10 @@
 import { Router, Request, Response } from "express";
-import { Job, Vent, sequelize } from "../../models";
+import { Job, Vent } from "../../models";
 import * as bcrypt from "bcrypt";
 import passport from "passport";
 require("../passport");
 
 const router: Router = Router();
-
-// TODO
-// Eventually remove or secure
-router.get("/", async (req: Request, res: Response) => {
-  const jobs = await Job.findAll({ order: [["createdAt", "DESC"]] });
-  return res.status(200).json(
-    jobs.map(j => ({
-      id: j.id,
-      name: j.name,
-      createdAt: j.createdAt
-    }))
-  );
-});
 
 interface IMoveJobData {
   id?: string;

--- a/app/controllers/JobController.ts
+++ b/app/controllers/JobController.ts
@@ -1,7 +1,9 @@
 import { Router, Request, Response } from "express";
-import { Job, Vent } from "../../models";
+import { Job, Vent, User } from "../../models";
 import * as bcrypt from "bcrypt";
 import passport from "passport";
+
+// Include our passport setup
 require("../passport");
 
 const router: Router = Router();
@@ -27,7 +29,7 @@ router.post(
       if (
         !jobName ||
         jobName.trim() === "" ||
-        // TODO Refactor when adding different job types
+        // TODO Refactor if adding different job types
         ["open", "close"].indexOf(jobName.trim()) < 0
       ) {
         errors.push({
@@ -54,11 +56,13 @@ router.post(
         continue;
       }
 
+      const user: User | null = req.user;
       const vent = await Vent.findOne({
         where: {
           id: moveJobData.id.trim(),
           serial: moveJobData.serial.trim(),
-          status: "registered"
+          status: "registered",
+          userId: user ? user.id : null
         }
       });
 

--- a/migrations/20190428201028-tie-vent-to-user.js
+++ b/migrations/20190428201028-tie-vent-to-user.js
@@ -1,0 +1,20 @@
+"use strict";
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn("vents", "userId", {
+      type: Sequelize.UUID,
+      allowNull: true,
+      references: { model: "users", key: "id" }
+    });
+    await queryInterface.addConstraint("vents", ["id", "userId"], {
+      type: "unique",
+      name: "vents_unique_id_userId"
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeConstraint("vents", "vents_unique_id_userId");
+    await queryInterface.removeColumn("vents", "userId");
+  }
+};

--- a/models/Vent.ts
+++ b/models/Vent.ts
@@ -1,4 +1,5 @@
 import * as Sequelize from "sequelize-typescript";
+import User from "./User";
 
 export type TVentStatus = "manufactured" | "registered";
 
@@ -19,4 +20,8 @@ export default class Vent extends Sequelize.Model<Vent> {
 
   @Sequelize.Column
   status: TVentStatus;
+
+  @Sequelize.ForeignKey(() => User)
+  @Sequelize.Column
+  userId: string;
 }


### PR DESCRIPTION
**Problem**
The system currently had no way of associating a vent to a user. This prevents the user from being able to list the vents they've got on file.

**Solution**
- Add a userId to the vents table, which would allow a user to make a request to the server to retrieve the registered vents associated with them.
- Add /api/v1/vents GET that returns the authenticated users vents

**Notes**
There's additional tweaks in this PR and the branch name is bad, but I'm too lazy to change it.